### PR TITLE
Fix 1.20.5 JAR not being executable

### DIFF
--- a/1.20.5/src/main/java/com/mojang/slicer/Main.java
+++ b/1.20.5/src/main/java/com/mojang/slicer/Main.java
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-package slicer;
+package com.mojang.slicer;
 
 import com.mojang.slicer.Box;
 import com.mojang.slicer.InputFile;


### PR DESCRIPTION
The package for the 1.20.5 `Main` class is `slicer` instead of `com.mojang.slicer`, which makes the JAR not executable, as the manifest points to `com.mojang.slicer.Main` and not `slicer.Main`. This seems to be a mistake, as all other `Main` classes are in the `com.mojang.slicer` package.

This changes the package and adjusts the directory to be consistent with other `Main` classes, and thus fixes the issue of the JAR not being executable.

Fixes #10.