### PR TITLE
Slice experience orbs and moon phases

### DIFF
--- a/1.20.5/build.gradle
+++ b/1.20.5/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'com.mojang'
-version '1.1.5-SNAPSHOT'
+version '1.1.6-SNAPSHOT'
 
 mainClassName = "com.mojang.slicer.Main"
 archivesBaseName = distributions.main.distributionBaseName = "slicer-1.20.5"

--- a/1.20.5/src/main/java/com/mojang/slicer/Main.java
+++ b/1.20.5/src/main/java/com/mojang/slicer/Main.java
@@ -85,29 +85,29 @@ public class Main {
     ),
     private static final List<InputFile> INPUTS = List.of(
         input("assets/minecraft/textures/entity/experience_orb.png",
-            mapDecoration("smallest", 0),
-            mapDecoration("value_3", 1),
-            mapDecoration("value_7", 2),
-            mapDecoration("value_17", 3),
-            mapDecoration("value_37", 4),
-            mapDecoration("value_73", 5),
-            mapDecoration("value_149", 6),
-            mapDecoration("value_307", 7),
-            mapDecoration("value_617", 8),
-            mapDecoration("value_1237", 9),
-            mapDecoration("value_2477", 10)
+            experienceOrb("smallest", 0),
+            experienceOrb("value_3", 1),
+            experienceOrb("value_7", 2),
+            experienceOrb("value_17", 3),
+            experienceOrb("value_37", 4),
+            experienceOrb("value_73", 5),
+            experienceOrb("value_149", 6),
+            experienceOrb("value_307", 7),
+            experienceOrb("value_617", 8),
+            experienceOrb("value_1237", 9),
+            experienceOrb("value_2477", 10)
         )
     ),
     private static final List<InputFile> INPUTS = List.of(
         input("assets/minecraft/textures/environment/moon_phases.png",
-            mapDecoration("moon_full", 0),
-            mapDecoration("moon_waning_gibbous", 1),
-            mapDecoration("moon_last_quarter", 2),
-            mapDecoration("moon_waning_crescent", 3),
-            mapDecoration("moon_new", 4),
-            mapDecoration("moon_waxing_crescent", 5),
-            mapDecoration("moon_first_quarter", 6),
-            mapDecoration("moon_waxing_gibbous", 7)
+            moonPhase("moon_full", 0),
+            moonPhase("moon_waning_gibbous", 1),
+            moonPhase("moon_last_quarter", 2),
+            moonPhase("moon_waning_crescent", 3),
+            moonPhase("moon_new", 4),
+            moonPhase("moon_waxing_crescent", 5),
+            moonPhase("moon_first_quarter", 6),
+            moonPhase("moon_waxing_gibbous", 7)
         )
     );
 

--- a/1.20.5/src/main/java/com/mojang/slicer/Main.java
+++ b/1.20.5/src/main/java/com/mojang/slicer/Main.java
@@ -45,6 +45,10 @@ public class Main {
         return new InputFile(path).outputs(outputs);
     }
 
+    private static InputFile move(final String inputPath, final String outputPath) {
+        return new InputFile(inputPath).outputs(new OutputFile(outputPath, new Box(0, 0, 1, 1, 1, 1)));
+    }
+
     private static final List<InputFile> INPUTS = List.of(
         input("assets/minecraft/textures/map/map_icons.png",
             mapDecoration("player", 0),

--- a/1.20.5/src/main/java/com/mojang/slicer/Main.java
+++ b/1.20.5/src/main/java/com/mojang/slicer/Main.java
@@ -37,7 +37,7 @@ public class Main {
         final int y = index / 2;
         return new OutputFile(
             "assets/minecraft/textures/celestial_body/" + path + ".png",
-            new Box(x * 32, y * 32, 32, 32, 128, 64)
+            new Box(x * 32, y * 32, 32, 32, 64, 128)
         );
     }
 

--- a/1.20.5/src/main/java/com/mojang/slicer/Main.java
+++ b/1.20.5/src/main/java/com/mojang/slicer/Main.java
@@ -23,6 +23,24 @@ public class Main {
         );
     }
 
+    private static OutputFile experienceOrb(final String path, final int index) {
+        final int x = index % 4;
+        final int y = index / 4;
+        return new OutputFile(
+            "assets/minecraft/textures/experience_orb/" + path + ".png",
+            new Box(x * 16, y * 16, 16, 16, 64, 64)
+        );
+    }
+
+    private static OutputFile moonPhase(final String path, final int index) {
+        final int x = index % 4;
+        final int y = index / 2;
+        return new OutputFile(
+            "assets/minecraft/textures/celestial_body/" + path + ".png",
+            new Box(x * 32, y * 32, 32, 32, 128, 64)
+        );
+    }
+
     private static InputFile input(final String path, final OutputFile... outputs) {
         return new InputFile(path).outputs(outputs);
     }
@@ -63,6 +81,33 @@ public class Main {
             mapDecoration("taiga_village", 31),
             mapDecoration("jungle_temple", 32),
             mapDecoration("swamp_hut", 33)
+        )
+    ),
+    private static final List<InputFile> INPUTS = List.of(
+        input("assets/minecraft/textures/entity/experience_orb.png",
+            mapDecoration("smallest", 0),
+            mapDecoration("value_3", 1),
+            mapDecoration("value_7", 2),
+            mapDecoration("value_17", 3),
+            mapDecoration("value_37", 4),
+            mapDecoration("value_73", 5),
+            mapDecoration("value_149", 6),
+            mapDecoration("value_307", 7),
+            mapDecoration("value_617", 8),
+            mapDecoration("value_1237", 9),
+            mapDecoration("value_2477", 10)
+        )
+    ),
+    private static final List<InputFile> INPUTS = List.of(
+        input("assets/minecraft/textures/environment/moon_phases.png",
+            mapDecoration("moon_full", 0),
+            mapDecoration("moon_waning_gibbous", 1),
+            mapDecoration("moon_last_quarter", 2),
+            mapDecoration("moon_waning_crescent", 3),
+            mapDecoration("moon_new", 4),
+            mapDecoration("moon_waxing_crescent", 5),
+            mapDecoration("moon_first_quarter", 6),
+            mapDecoration("moon_waxing_gibbous", 7)
         )
     );
 

--- a/1.20.5/src/main/java/com/mojang/slicer/Main.java
+++ b/1.20.5/src/main/java/com/mojang/slicer/Main.java
@@ -81,9 +81,7 @@ public class Main {
             mapDecoration("taiga_village", 31),
             mapDecoration("jungle_temple", 32),
             mapDecoration("swamp_hut", 33)
-        )
-    ),
-    private static final List<InputFile> INPUTS = List.of(
+        ),
         input("assets/minecraft/textures/entity/experience_orb.png",
             experienceOrb("smallest", 0),
             experienceOrb("value_3", 1),
@@ -96,9 +94,7 @@ public class Main {
             experienceOrb("value_617", 8),
             experienceOrb("value_1237", 9),
             experienceOrb("value_2477", 10)
-        )
-    ),
-    private static final List<InputFile> INPUTS = List.of(
+        ),
         input("assets/minecraft/textures/environment/moon_phases.png",
             moonPhase("moon_full", 0),
             moonPhase("moon_waning_gibbous", 1),

--- a/1.20.5/src/main/java/com/mojang/slicer/Main.java
+++ b/1.20.5/src/main/java/com/mojang/slicer/Main.java
@@ -33,7 +33,7 @@ public class Main {
     }
 
     private static OutputFile moonPhase(final String path, final int index) {
-        final int x = index % 2;
+        final int x = index % 4;
         final int y = index / 4;
         return new OutputFile(
             "assets/minecraft/textures/celestial_body/" + path + ".png",

--- a/1.20.5/src/main/java/com/mojang/slicer/Main.java
+++ b/1.20.5/src/main/java/com/mojang/slicer/Main.java
@@ -45,10 +45,6 @@ public class Main {
         return new InputFile(path).outputs(outputs);
     }
 
-    private static InputFile move(final String inputPath, final String outputPath) {
-        return new InputFile(inputPath).outputs(new OutputFile(outputPath, new Box(0, 0, 1, 1, 1, 1)));
-    }
-
     private static final List<InputFile> INPUTS = List.of(
         input("assets/minecraft/textures/map/map_icons.png",
             mapDecoration("player", 0),
@@ -108,6 +104,9 @@ public class Main {
             moonPhase("moon_waxing_crescent", 5),
             moonPhase("moon_first_quarter", 6),
             moonPhase("moon_waxing_gibbous", 7)
+        ),
+        input("assets/minecraft/textures/environment/sun.png",
+            new OutputFile("assets/minecraft/textures/celestial_body/sun.png", new Box(0, 0, 1, 1, 1, 1))
         )
     );
 

--- a/1.20.5/src/main/java/com/mojang/slicer/Main.java
+++ b/1.20.5/src/main/java/com/mojang/slicer/Main.java
@@ -33,11 +33,11 @@ public class Main {
     }
 
     private static OutputFile moonPhase(final String path, final int index) {
-        final int x = index % 4;
-        final int y = index / 2;
+        final int x = index % 2;
+        final int y = index / 4;
         return new OutputFile(
             "assets/minecraft/textures/celestial_body/" + path + ".png",
-            new Box(x * 32, y * 32, 32, 32, 64, 128)
+            new Box(x * 32, y * 32, 32, 32, 128, 64)
         );
     }
 


### PR DESCRIPTION
With 1.20.5's long-awaited splitting of map icons into individual files, this means that the only two classic-style texture atlases yet to be split are experience orbs and moon phases. Since there's just two of them, why not rip this bandaid off and get them split just before 1.20.5 releases to limit any subsequent migrations needed by resource pack authors?

Changes:
- The file assets/minecraft/textures/entity/experience_orb.png is now split into eleven texture files, one for each orb, in assets/minecraft/textures/experience_orb
- The file assets/minecraft/textures/environment/moon_phases.png is now split into eight texture files, one for each phase, in assets/minecraft/textures/celestial_body
- The file assets/minecraft/textures/environment/sun.png has been automatically moved to assets/minecraft/textures/celestial_body alongside the split moon phases

There would be two new atlases generated to deal with these newly split textures - one for experience orbs and another for all celestial bodies (the sun and all phases of the moon).

Obviously a commit like this is probably trivial compared to the code changes needed in the actual game to support split textures like these, but in the slim event that this does happen I hope I've made the process just a bit smoother for all involved. I would have done this a month ago, but #10 was a blocker.

Some things to note that may be relevant:
- The sun and moon are rendered mirrored in-game compared to their actual textures (https://bugs.mojang.com/browse/MC-241036) - it may be a good idea to have slicer output flipped versions of these textures if that bug is fixed in the same version that splits these atlases.
- I'm not sure if transferring the experience orbs' rendered translucency and color animation to the texture files themselves and using proper texture animation with json files and such would also be relevant, or if those would be better off left hardcoded.