### PR TITLE
Don't copy presets/isles.png

### DIFF
--- a/1.20.2/src/main/java/com/mojang/slicer/Main.java
+++ b/1.20.2/src/main/java/com/mojang/slicer/Main.java
@@ -763,7 +763,6 @@ public class Main {
         copy("hanging_signs/oak"),
         copy("hanging_signs/spruce"),
         copy("hanging_signs/warped"),
-        copy("presets/isles"),
         copy("title/background/panorama_0"),
         copy("title/background/panorama_1"),
         copy("title/background/panorama_2"),


### PR DESCRIPTION
Fixes #16.

As described in the ticket, isles.png goes completely unused by the game, as the pre-1.13 customized format is no longer used, and there is no menu associated with it. It can therefore be removed from the game entirely without impacting it at all.

This pull request removes the line that causes it to get copied over to the next resource pack format, meaning that it gets left behind as is done with all other unused GUI textures and regions. It should help to make it clear that the file is unused.